### PR TITLE
feat: enable JavaDoc "indent continuation lines" property

### DIFF
--- a/java/intellij/intellij-java-oilmod-style.xml
+++ b/java/intellij/intellij-java-oilmod-style.xml
@@ -80,6 +80,7 @@
         <package name="" withSubpackages="true" static="false" />
       </value>
     </option>
+    <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
     <option name="JD_INDENT_ON_CONTINUATION" value="true" />
   </JavaCodeStyleSettings>
   <Python>

--- a/java/intellij/intellij-java-oilmod-style.xml
+++ b/java/intellij/intellij-java-oilmod-style.xml
@@ -66,6 +66,22 @@
   <JSCodeStyleSettings>
     <option name="INDENT_CHAINED_CALLS" value="false" />
   </JSCodeStyleSettings>
+  <JavaCodeStyleSettings>
+    <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+      <value />
+    </option>
+    <option name="IMPORT_LAYOUT_TABLE">
+      <value>
+        <package name="" withSubpackages="true" static="true" />
+        <emptyLine />
+        <package name="" withSubpackages="true" static="false" />
+      </value>
+    </option>
+    <option name="JD_INDENT_ON_CONTINUATION" value="true" />
+  </JavaCodeStyleSettings>
   <Python>
     <option name="USE_CONTINUATION_INDENT_FOR_ARGUMENTS" value="true" />
   </Python>


### PR DESCRIPTION
- enable Java Doc formatting option "Indent continuation lines" (as of input from @ingvildodegard)
- enable Java Doc formatting option "Preserve line feeds" (as of input from @jrogde )

![image](https://github.com/equinor/oilmod1-code-style/assets/6915328/9c9a6736-4052-42cd-9101-a1a9d6d50e8b)