### PR TITLE
remove requirement of blank line before end of class interface

### DIFF
--- a/java/checkstyle/oilmod-checkstyle.xml
+++ b/java/checkstyle/oilmod-checkstyle.xml
@@ -306,18 +306,6 @@
         -->
         <module name="SuppressWarningsHolder" />
     </module>
-    <module name="RegexpMultiline">
-        <property name="id" value="RegexpMultilineEmptyRowAfterClassDef"/>
-        <property name="format" value="^([^\r\n ]+ )*(class|interface|@interface|enum) [^{]*\{[\r]?\n[^\r\n}]"/>
-        <property name="message" value="Leave blank line after class/interface/@interface/enum definition."/>
-        <property name="fileExtensions" value="groovy,java"/>
-    </module>
-    <module name="RegexpMultiline">
-        <property name="id" value="RegexpMultilineEmptyRowBeforeClassEnd"/>
-        <property name="format" value="[^\r\n{][\r]?\n\}[\r]?\n"/>
-        <property name="message" value="Leave blank line before end of class/interface/@interface/enum."/>
-        <property name="fileExtensions" value="groovy,java"/>
-    </module>
     <module name="NewlineAtEndOfFile" />
     <module name="SuppressWarningsFilter" />
 </module>


### PR DESCRIPTION
- remove requirement of blank line before end of class interface (does not exists in Google code style)

This change is backward compatible -- will not trigger new violations on existing blank line at the end of class\interface.
